### PR TITLE
Groups color fixed

### DIFF
--- a/src/component/navbar.module.css
+++ b/src/component/navbar.module.css
@@ -129,7 +129,7 @@
 }
 
 .subMenuItem {
-    color: white;
+    color: black;
     padding: 0.5rem 0;
     cursor: pointer;
     opacity: 0; /* Start with hidden items */


### PR DESCRIPTION
Fixed where the group tab was white to black to fit the rest of navbar.